### PR TITLE
Validate user's item amount before sending items

### DIFF
--- a/nekoyume/models.py
+++ b/nekoyume/models.py
@@ -1013,6 +1013,9 @@ class User():
         return self.move(Sleep())
 
     def send(self, item_name, amount, receiver):
+        if self.avatar().items[item_name] < int(amount):
+            raise InvalidMoveError
+
         return self.move(Send(details={
             'item_name': item_name,
             'amount': amount,

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 
+from nekoyume.exc import InvalidMoveError
 from nekoyume.models import (Block,
                              CreateNovice,
                              HackAndSlash,
@@ -9,7 +10,6 @@ from nekoyume.models import (Block,
                              Move,
                              Node,
                              Say,
-                             Send,
                              Sleep,
                              User)
 
@@ -80,14 +80,14 @@ def test_send(fx_user, fx_user2, fx_novice_status):
 
     assert fx_user.avatar(block.id).items['GOLD'] == 8
 
-    move = fx_user.move(Send(details={
-        'item_name': 'GOLD',
-        'amount': 1,
-        'receiver': fx_user2.address}))
+    move = fx_user.send('GOLD', 1, fx_user2.address)
     block = fx_user.create_block([move])
 
     assert fx_user.avatar(block.id).items['GOLD'] == 15
     assert fx_user2.avatar(block.id).items['GOLD'] == 1
+
+    with pytest.raises(InvalidMoveError):
+        fx_user.send('GOLD', 100, fx_user2.address)
 
 
 def test_block_validation(fx_user, fx_novice_status):


### PR DESCRIPTION
Hi.

I took a look at the code and found out that users can generate items by sending more items than they actually have. 
(Currently, the validation logic is only in the sender side, so a receiver can receive the items even if the sender fails to send the items.)

I made a patch to prevent it. I'm not sure that this patch is the best option, so please feel free to comment your thought. 

Thanks.