### PR TITLE
Prevent users from sending items with a negative or zero amount

### DIFF
--- a/nekoyume/models.py
+++ b/nekoyume/models.py
@@ -844,6 +844,13 @@ class Send(Move):
         if not avatar:
             avatar = Avatar.get(self.user, self.block_id - 1)
 
+        if int(self.details['amount']) <= 0:
+            return avatar, dict(
+                type='send',
+                result='fail',
+                message="You can't send items with a negative or zero amount."
+            )
+
         if (self.details['item_name'] not in avatar.items or
            avatar.items[self.details['item_name']]
            - int(self.details['amount']) < 0):
@@ -1013,7 +1020,7 @@ class User():
         return self.move(Sleep())
 
     def send(self, item_name, amount, receiver):
-        if self.avatar().items[item_name] < int(amount):
+        if self.avatar().items[item_name] < int(amount) or int(amount) <= 0:
             raise InvalidMoveError
 
         return self.move(Send(details={

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -10,6 +10,7 @@ from nekoyume.models import (Block,
                              Move,
                              Node,
                              Say,
+                             Send,
                              Sleep,
                              User)
 
@@ -86,8 +87,33 @@ def test_send(fx_user, fx_user2, fx_novice_status):
     assert fx_user.avatar(block.id).items['GOLD'] == 15
     assert fx_user2.avatar(block.id).items['GOLD'] == 1
 
+
+def test_send_validation(fx_user, fx_user2, fx_novice_status):
+    move = fx_user.create_novice(fx_novice_status)
+    move2 = fx_user2.create_novice(fx_novice_status)
+    block = fx_user.create_block([move, move2])
+
+    assert fx_user.avatar(block.id).items['GOLD'] == 8
+
     with pytest.raises(InvalidMoveError):
         fx_user.send('GOLD', 100, fx_user2.address)
+
+    with pytest.raises(InvalidMoveError):
+        fx_user.send('GOLD', -1, fx_user2.address)
+
+    with pytest.raises(InvalidMoveError):
+        fx_user.send('GOLD', 0, fx_user2.address)
+
+    # Even if a move object is created somehow,
+    # sending items with a negative amount must be prevented.
+    move = fx_user.move(Send(details={
+        'item_name': 'GOLD',
+        'amount': -1,
+        'receiver': fx_user2.address}))
+    block = fx_user.create_block([move])
+
+    assert fx_user.avatar(block.id).items['GOLD'] == 16
+    assert fx_user2.avatar(block.id).items['GOLD'] == 0
 
 
 def test_block_validation(fx_user, fx_novice_status):


### PR DESCRIPTION
Currently, users can generate items by sending items with negative amount. This patch prevent users from sending items with a negative or zero amount. Thanks.