### PR TITLE
 Flush the block deletions to the database to avoid getting stale blocks from the database

### DIFF
--- a/nekoyume/models.py
+++ b/nekoyume/models.py
@@ -369,6 +369,11 @@ class Block(db.Model):
                 move.block_id = None
             session.delete(block)
 
+        # Flush the above deletions to the database.
+        # If we don't flush here,
+        # stale objects can be fetched when validating blocks.
+        session.flush()
+
         from_ = branch_point + 1
         limit = 1000
         while True:

--- a/nekoyume/models.py
+++ b/nekoyume/models.py
@@ -425,15 +425,15 @@ class Block(db.Model):
                 break
             from_ += limit
             try:
-                db.session.commit()
+                session.commit()
             except IntegrityError:
-                db.session.rollback()
+                session.rollback()
                 return False
 
         try:
-            db.session.commit()
+            session.commit()
         except IntegrityError:
-            db.session.rollback()
+            session.rollback()
             return False
         return True
 


### PR DESCRIPTION
If a new node generates some blocks and try to sync later, the node's invalid blocks will be deleted while syncing. But syncing without flushing the invalid block deletions can cause block validation failure, because stale blocks can be fetched while validating new blocks.

I've also added some test codes to validate the scenario. Thanks.