### PR TITLE
Fix broken Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*.db
+*.egg-info
+.git
+.secret_key

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install --trusted-host pypi.python.org -r requirements.txt
 RUN nekoyume init
 
-# Make port 80 available to the world outside this container
-EXPOSE 80
+# Make port 8080 available to the world outside this container
+EXPOSE 8080
 
 # Define environment variable
-ENV PORT 80
+ENV PORT 8080
 
 # Run app.py when the container launches
-CMD ["honcho", "start"]
+CMD ["bash", "-c", "nekoyume init && honcho start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,13 @@ services:
     networks:
       - nekoyume-net
   nekoyume:
-    image: "nekoyume:latest"
+    build: .
+    image: "nekoyume/nekoyume"
     environment:
-      - REDIS_URL=redis://redis:6379/
+      - REDIS_URL=redis://redis:6379
+      - C_FORCE_ROOT=true
     ports:
-      - "4000:80"
+      - "4000:8080"
     depends_on:
       - redis
     networks:


### PR DESCRIPTION
- Added *.dockerignore* so that built images became lighter.
- The exposed port number was changed from 80 to 8080 since opening the port number 80 requires super user privilege on Linux.
- Now `docker-compose` builds a local *Dockerfile* rather than pulls an image from Docker Hub.