### PR TITLE
Run Nekoyume in more Docker-native way

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@
 *.egg-info
 .git
 .secret_key
+Dockerfile
+docker-compose.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,31 @@
 # Use an official Python runtime as a parent image
 FROM python:3.6-slim
 
-# Set the working directory to /app
-WORKDIR /app
-
-# Copy the current directory contents into the container at /app
-ADD . /app
-
 # runtime dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		build-essential \
 		libgmp-dev \
+        wget \
 	&& rm -rf /var/lib/apt/lists/*
+RUN wget https://github.com/eficode/wait-for/raw/master/wait-for
+RUN chmod +x wait-for
+RUN mv wait-for /usr/bin/
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Cache dependencies if possible
+COPY setup.py /app
+RUN python -c 'from setup import *; print("\n".join(install_requires))' \
+        > /tmp/requirements.txt && \
+    pip install -r /tmp/requirements.txt && \
+    rm /tmp/requirements.txt
+
+# Copy the current directory contents into the container at /app
+COPY . /app
 
 # Install any needed packages specified in requirements.txt
 RUN pip install --trusted-host pypi.python.org -r requirements.txt
-RUN nekoyume init
 
 # Make port 8080 available to the world outside this container
 EXPOSE 8080
@@ -24,4 +34,5 @@ EXPOSE 8080
 ENV PORT 8080
 
 # Run app.py when the container launches
+ENTRYPOINT ["bash", "-c"]
 CMD ["bash", "-c", "nekoyume init && honcho start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,36 @@
 version: '2'
 services:
   redis:
-    image: "redis:alpine"
-    networks:
-      - nekoyume-net
-  nekoyume:
+    image: redis:alpine
+    networks: [nekoyume-net]
+  sync: &app
     build: .
-    image: "nekoyume/nekoyume"
-    environment:
-      - REDIS_URL=redis://redis:6379
-      - C_FORCE_ROOT=true
+    image: nekoyume/nekoyume
+    command: nekoyume sync
+    environment: &app_environments
+      REDIS_URL: redis://redis:6379
+    depends_on: [redis]
+    networks: [nekoyume-net]
+  web:
+    <<: *app
+    command: >
+      gunicorn
+        -b 0.0.0.0:8080
+        -w 3
+        -k gevent
+        --log-level debug
+        nekoyume.app:app
     ports:
-      - "4000:8080"
-    depends_on:
-      - redis
-    networks:
-      - nekoyume-net
+    - "4000:8080"
+  worker:
+    <<: *app
+    command: >
+      celery
+        -A nekoyume.app.cel
+        worker
+          -l info
+    environment:
+      <<: *app_environments
+      C_FORCE_ROOT: "true"
 networks:
   nekoyume-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,34 +1,50 @@
-version: '2'
+version: '3'
 services:
   redis:
     image: redis:alpine
     networks: [nekoyume-net]
+  postgres:
+    image: postgres:alpine
+    networks: [nekoyume-net]
+    environment:
+      POSTGRES_PASSWORD: nekoyume
+      POSTGRES_DB: nekoyume
   sync: &app
     build: .
     image: nekoyume/nekoyume
-    command: nekoyume sync
+    command:
+    -
+      nekoyume init --skip-sync &&
+      nekoyume sync
     environment: &app_environments
+      DATABASE_URL: postgresql://postgres:nekoyume@postgres/nekoyume
       REDIS_URL: redis://redis:6379
-    depends_on: [redis]
+    depends_on: [postgres, redis]
     networks: [nekoyume-net]
   web:
     <<: *app
-    command: >
+    command:
+    -
+      nekoyume init --skip-sync &&
       gunicorn
         -b 0.0.0.0:8080
         -w 3
         -k gevent
         --log-level debug
-        nekoyume.app:app
+        nekoyume.app:app;
+    depends_on: [sync]
     ports:
     - "4000:8080"
   worker:
     <<: *app
-    command: >
+    command:
+    -
+      nekoyume init --skip-sync &&
       celery
         -A nekoyume.app.cel
         worker
-          -l info
+          -l info;
+    depends_on: [sync]
     environment:
       <<: *app_environments
       C_FORCE_ROOT: "true"

--- a/setup.py
+++ b/setup.py
@@ -5,75 +5,84 @@ from os import path
 
 here = path.abspath(path.dirname(__file__))
 
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
-    long_description = f.read()
 
-setup(
-    name='nekoyume',
-    version='0.0.3',
-    description='Decentralized MMORPG based on Dungeon World',
-    long_description=long_description,
-    url='https://github.com/nekoyume/nekoyume',
-    license='LICENSE.txt',
-    author='JC Kim',
-    author_email='jc@nekoyu.me',
-    classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Intended Audience :: Other Audience',
-        'Topic :: Database :: Database Engines/Servers',
-        'Topic :: Games/Entertainment :: Role-Playing',
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.6',
-    ],
-    keywords='blockchain mmorpg game',
-    packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    install_requires=[
-        'bencode.py >= 2.0.0, < 2.1.0',
-        'blinker >= 1.4, < 1.5',
-        'celery >= 4.1.0, < 4.2.0',
-        'click >= 6.7, < 7.0',
-        'Flask >= 0.12.2, < 0.13.0',
-        'Flask-Babel >= 0.11.2, < 0.12.0',
-        'Flask-Caching >= 1.4.0, < 1.5.0',
-        'Flask-SQLAlchemy >= 2.3.2, < 2.4.0',
-        'gevent == 1.3.1',
-        'gunicorn >= 19.7.1, < 19.8.0',
-        'psycopg2 >= 2.7.5, < 2.8.0',
-        'ptpython == 0.41',
-        'pycrypto == 2.6',
-        'python_bitcoinlib == 0.9.0',
-        'pytz >= 2018.3',
-        'raven==6.9.0',
-        'redis >= 2.10.6, < 2.11.0',
-        'requests >= 2.18.4, < 2.19.0',
-        'seccure >= 0.3.2, < 0.4.0',
-        'SQLAlchemy >= 1.2.2, < 1.3.0',
-        'tablib >= 0.12.1, < 0.13.0',
-    ],
-    extras_require={
-        'dev': [
-            'flake8 >= 3.5.0, < 3.6.0',
-            'recommonmark==0.4.0',
-            'Sphinx >= 1.7.1, < 1.8.0',
-            'sphinx-rtd-theme==0.2.4',
+def long_description():
+    try:
+        with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+            return f.read()
+    except IOError:
+        pass
+
+
+install_requires = [
+    'bencode.py >= 2.0.0, < 2.1.0',
+    'blinker >= 1.4, < 1.5',
+    'celery >= 4.1.0, < 4.2.0',
+    'click >= 6.7, < 7.0',
+    'Flask >= 0.12.2, < 0.13.0',
+    'Flask-Babel >= 0.11.2, < 0.12.0',
+    'Flask-Caching >= 1.4.0, < 1.5.0',
+    'Flask-SQLAlchemy >= 2.3.2, < 2.4.0',
+    'gevent == 1.3.1',
+    'gunicorn >= 19.7.1, < 19.8.0',
+    'psycopg2 >= 2.7.5, < 2.8.0',
+    'ptpython == 0.41',
+    'pycrypto == 2.6',
+    'python_bitcoinlib == 0.9.0',
+    'pytz >= 2018.3',
+    'raven==6.9.0',
+    'redis >= 2.10.6, < 2.11.0',
+    'requests >= 2.18.4, < 2.19.0',
+    'seccure >= 0.3.2, < 0.4.0',
+    'SQLAlchemy >= 1.2.2, < 1.3.0',
+    'tablib >= 0.12.1, < 0.13.0',
+]
+
+if __name__ == '__main__':
+    setup(
+        name='nekoyume',
+        version='0.0.3',
+        description='Decentralized MMORPG based on Dungeon World',
+        long_description=long_description(),
+        url='https://github.com/nekoyume/nekoyume',
+        license='LICENSE.txt',
+        author='JC Kim',
+        author_email='jc@nekoyu.me',
+        classifiers=[
+            'Development Status :: 2 - Pre-Alpha',
+            'Intended Audience :: Other Audience',
+            'Topic :: Database :: Database Engines/Servers',
+            'Topic :: Games/Entertainment :: Role-Playing',
+            'License :: OSI Approved :: MIT License',
+            'Programming Language :: Python :: 3.6',
         ],
-        'test': [
-            'pytest >= 3.4.2, < 3.5.0',
-            'pytest-localserver >= 0.4.1, < 0.5',
-            'codecov >= 2.0.15, < 2.1.0',
-        ],
-    },
-    package_data={
-        'nekoyume': ['data/*', 'templates/*.html'],
-    },
-    entry_points={
-        'console_scripts': [
-            'nekoyume = nekoyume.cli:cli',
-        ],
-    },
-    project_urls={
-        'Bug Reports': 'https://github.com/nekoyume/nekoyume/issues',
-        'Funding': 'https://nekoyu.me/',
-        'Source': 'https://github.com/nekoyume/nekoyume/',
-    },
-)
+        keywords='blockchain mmorpg game',
+        packages=find_packages(exclude=['contrib', 'docs', 'tests']),
+        install_requires=install_requires,
+        extras_require={
+            'dev': [
+                'flake8 >= 3.5.0, < 3.6.0',
+                'recommonmark==0.4.0',
+                'Sphinx >= 1.7.1, < 1.8.0',
+                'sphinx-rtd-theme==0.2.4',
+            ],
+            'test': [
+                'pytest >= 3.4.2, < 3.5.0',
+                'pytest-localserver >= 0.4.1, < 0.5',
+                'codecov >= 2.0.15, < 2.1.0',
+            ],
+        },
+        package_data={
+            'nekoyume': ['data/*', 'templates/*.html'],
+        },
+        entry_points={
+            'console_scripts': [
+                'nekoyume = nekoyume.cli:cli',
+            ],
+        },
+        project_urls={
+            'Bug Reports': 'https://github.com/nekoyume/nekoyume/issues',
+            'Funding': 'https://nekoyu.me/',
+            'Source': 'https://github.com/nekoyume/nekoyume/',
+        },
+    )


### PR DESCRIPTION
In order to run Nekoyume in more Docker-native way, this patch adjusted several points:

- *Dockerfile* recipe became well-cached by changing orders of dependency resolution and ignoring non-critical files.
- No more use *Procfile* but utilize `docker-compose` intensively instead.
- Use PostgreSQL instead of SQLite.

Fixed some minor bugs as well:

- Multiple `nekoyume init` or `Node.get()` processes became possible to run in parallel without `IntegrityError`.
- `nekoyume init` became idempotent.