### PR TITLE
Binary-based block nonce (i.e., suffix)

### DIFF
--- a/nekoyume/api.py
+++ b/nekoyume/api.py
@@ -166,7 +166,7 @@ def post_block():
     block.prev_hash = new_block['prev_hash']
     block.hash = new_block['hash']
     block.difficulty = new_block['difficulty']
-    block.suffix = new_block['suffix']
+    block.suffix = bytes.fromhex(new_block['suffix'])
     block.root_hash = new_block['root_hash']
 
     for new_move in new_block['moves']:

--- a/nekoyume/api.py
+++ b/nekoyume/api.py
@@ -158,16 +158,7 @@ def post_block():
         return jsonify(result='failed',
                        message="new block isn't our next block."), 403
 
-    block = Block()
-    block.id = new_block['id']
-    block.creator = new_block['creator']
-    block.created_at = datetime.datetime.strptime(
-        new_block['created_at'], '%Y-%m-%d %H:%M:%S.%f')
-    block.prev_hash = new_block['prev_hash']
-    block.hash = new_block['hash']
-    block.difficulty = new_block['difficulty']
-    block.suffix = bytes.fromhex(new_block['suffix'])
-    block.root_hash = new_block['root_hash']
+    block = Block.deserialize(new_block)
 
     for new_move in new_block['moves']:
         move = Move.query.get(new_move['id'])

--- a/nekoyume/models.py
+++ b/nekoyume/models.py
@@ -202,6 +202,15 @@ class Block(db.Model):
     created_at = db.Column(db.DateTime, nullable=False,
                            default=datetime.datetime.utcnow)
     size_limit = 10000
+    __table_args__ = (
+        db.CheckConstraint(id > 0),
+        db.CheckConstraint(
+            db.case([
+                (id == 1, prev_hash.is_(None)),
+            ], else_=prev_hash.isnot(None))
+        ),
+        db.CheckConstraint((id == 1) | (difficulty > 0)),
+    )
 
     @property
     def valid(self) -> bool:

--- a/nekoyume/models.py
+++ b/nekoyume/models.py
@@ -212,6 +212,22 @@ class Block(db.Model):
         db.CheckConstraint((id == 1) | (difficulty > 0)),
     )
 
+    @classmethod
+    def deserialize(cls, serialized: dict) -> 'Block':
+        return cls(
+            id=serialized['id'],
+            creator=serialized['creator'],
+            created_at=datetime.datetime.strptime(
+                serialized['created_at'],
+                '%Y-%m-%d %H:%M:%S.%f'
+            ),
+            prev_hash=serialized['prev_hash'],
+            hash=serialized['hash'],
+            difficulty=serialized['difficulty'],
+            suffix=bytes.fromhex(serialized['suffix']),
+            root_hash=serialized['root_hash'],
+        )
+
     @property
     def valid(self) -> bool:
         """Check if this object is valid or not"""
@@ -402,16 +418,7 @@ class Block(db.Model):
             if len(response.json()['blocks']) == 0:
                 break
             for new_block in response.json()['blocks']:
-                block = Block()
-                block.id = new_block['id']
-                block.creator = new_block['creator']
-                block.created_at = datetime.datetime.strptime(
-                    new_block['created_at'], '%Y-%m-%d %H:%M:%S.%f')
-                block.prev_hash = new_block['prev_hash']
-                block.hash = new_block['hash']
-                block.difficulty = new_block['difficulty']
-                block.suffix = bytes.fromhex(new_block['suffix'])
-                block.root_hash = new_block['root_hash']
+                block = Block.deserialize(new_block)
 
                 for new_move in new_block['moves']:
                     move = session.query(Move).get(new_move['id'])

--- a/tests/hashcash_test.py
+++ b/tests/hashcash_test.py
@@ -1,0 +1,16 @@
+import hashlib
+import os
+
+from pytest import mark
+
+from nekoyume.hashcash import check, _mint
+
+
+@mark.parametrize('challenge', [os.urandom(40) for _ in range(5)])
+@mark.parametrize('bits', range(4, 17, 4))
+def test_mint(challenge, bits):
+    answer = _mint(challenge.hex(), bits)
+    stamp = challenge.hex() + answer
+    digest = hashlib.sha256(stamp.encode())
+    assert digest.hexdigest().startswith('0' * (bits // 4))
+    assert check(stamp)

--- a/tests/hashcash_test.py
+++ b/tests/hashcash_test.py
@@ -3,14 +3,31 @@ import os
 
 from pytest import mark
 
-from nekoyume.hashcash import check, _mint
+from nekoyume.hashcash import check, has_leading_zero_bits, _mint
 
 
 @mark.parametrize('challenge', [os.urandom(40) for _ in range(5)])
 @mark.parametrize('bits', range(4, 17, 4))
 def test_mint(challenge, bits):
-    answer = _mint(challenge.hex(), bits)
-    stamp = challenge.hex() + answer
-    digest = hashlib.sha256(stamp.encode())
-    assert digest.hexdigest().startswith('0' * (bits // 4))
+    answer = _mint(challenge, bits)
+    stamp = challenge + answer
+    digest = hashlib.sha256(stamp)
+    assert has_leading_zero_bits(digest.digest(), bits)
     assert check(stamp)
+
+
+def test_has_leading_zero_bits():
+    def f(digest: bytes, bits: int) -> bool:
+        print(  # noqa: T001
+            f'Expect leading {bits} zero bits in the {digest!r} '
+            f'({digest.hex()} = {" ".join(f"{b:08b}" for b in digest)})'
+        )
+        return has_leading_zero_bits(digest, bits)
+    assert f(b'\x80abc', 0)
+    assert not f(b'\x80abc', 1)
+    for bits in range(9):
+        assert f(b'\0\x80', bits)
+    assert not f(b'\0\x80', 9)
+    assert f(b'\0\x7f', 9)
+    assert not f(b'\0\x7f', 10)
+    assert f(b'\0?', 10)

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -270,20 +270,8 @@ def test_flush_session_while_syncing(fx_user, fx_session, fx_other_session, fx_n
                    "suffix": "32"}]
 
     def add_block(new_block):
-        # FIXME: this deserialization code is duplicate with post_block() in
-        # the api.py file.  Shouldn't it be extracted to a function?
-        block = Block()
-        block.id = new_block['id']
-        block.creator = new_block['creator']
-        block.created_at = datetime.datetime.strptime(
-            new_block['created_at'], '%Y-%m-%d %H:%M:%S.%f')
-        block.prev_hash = new_block['prev_hash']
-        block.hash = new_block['hash']
-        block.difficulty = new_block['difficulty']
-        block.suffix = bytes.fromhex(new_block['suffix'])
-        block.root_hash = new_block['root_hash']
+        block = Block.deserialize(new_block)
         fx_session.add(block)
-
         return block
 
     valid_block1 = add_block(new_blocks[0])

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -258,16 +258,17 @@ def test_flush_session_while_syncing(fx_user, fx_session, fx_other_session, fx_n
                    "moves": [],
                    "prev_hash": None,
                    "root_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                   "suffix": "30"},
+                   "suffix": "0"},
                   {"created_at": "2018-04-13 11:36:17.935392",
                    "creator": "ET8ngv45qwhkDiJS1ZrUxndcGTzHxjPZDs",
                    "difficulty": 1,
-                   "hash": "0d357ed864822c6cc423d2c0cda1b76397403483511f53644359c14527841d55",
+                   "hash": "014c44b9382a45c2a70d817c090e6b78af22b8f34b57fd7edb474344f25c439c",
                    "id": 2,
+                   "version": 2,
                    "moves": [],
                    "prev_hash": "da0182c494660af0d9dd288839ceb86498708f38c800363cd46ed1730013a4d8",
                    "root_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                   "suffix": "32"}]
+                   "suffix": "0b"}]
 
     def add_block(new_block):
         block = Block.deserialize(new_block)

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -258,7 +258,7 @@ def test_flush_session_while_syncing(fx_user, fx_session, fx_other_session, fx_n
                    "moves": [],
                    "prev_hash": None,
                    "root_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                   "suffix": "0"},
+                   "suffix": "30"},
                   {"created_at": "2018-04-13 11:36:17.935392",
                    "creator": "ET8ngv45qwhkDiJS1ZrUxndcGTzHxjPZDs",
                    "difficulty": 1,
@@ -267,9 +267,11 @@ def test_flush_session_while_syncing(fx_user, fx_session, fx_other_session, fx_n
                    "moves": [],
                    "prev_hash": "da0182c494660af0d9dd288839ceb86498708f38c800363cd46ed1730013a4d8",
                    "root_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                   "suffix": "2"}]
+                   "suffix": "32"}]
 
     def add_block(new_block):
+        # FIXME: this deserialization code is duplicate with post_block() in
+        # the api.py file.  Shouldn't it be extracted to a function?
         block = Block()
         block.id = new_block['id']
         block.creator = new_block['creator']
@@ -278,7 +280,7 @@ def test_flush_session_while_syncing(fx_user, fx_session, fx_other_session, fx_n
         block.prev_hash = new_block['prev_hash']
         block.hash = new_block['hash']
         block.difficulty = new_block['difficulty']
-        block.suffix = new_block['suffix']
+        block.suffix = bytes.fromhex(new_block['suffix'])
         block.root_hash = new_block['root_hash']
         fx_session.add(block)
 


### PR DESCRIPTION
*Note that this changes the protocol; the representation of block `"suffix"` field became from a UTF-8 string to an arbitrary byte string.*

This patch enables more sophisticated way to balance difficulty by making block nonce based on binary instead of hexadecimal.  Since it had been based on hexadecimal, the difficulty practically had been able to escalate four steps at least (as one hexadecimal digit consists of four bits).

First of all, to represent block nonces in binary, I changed the type of `Block.suffix` column from `String` to `LargeBinary`.  This column type corresponds to `bytea` on PostgreSQL, and removes UTF-8 encoding/decoding on SQLite (FYI SQLite in itself doesn't deal with Unicode strings; SQLAlchemy's `String`/`Unicode` types make assumption on its character encoding).

As the representation became an arbitrary byte string, we now need to deal with representing a blob (byte string) in JSON.  There's been several options in the practice — base64, hexadecimal, etc.  I chose coding them in hexadecimal, because it's good at approximately showing leading zeros (at least more than 3-bits difficulty) and a nonce is hardly likely to lengthen.  On the other hand, bencode in itself doesn't deal with Unicode strings from the start; we has encoded Unicode strings in UTF-8 first in order to include them in a bencode serialization.  So `suffix` (i.e., block nonce) became to be included without any encoding in a bencode serialization.  You could find that `bytes.fromhex()`/`.hex()` methods are called conditionally in serialization/deserialization processes.

The `_mint()`/`check()` function in the `nekoyume.hashcash` module had truncated difficulty by 4 bits, but this behavior is gone.  These functions now have minimum unit tests as well.

Lastly, although it's off-topic, I added some check constraints on the `Block` table.  It enables database-level assumptions on data.  I believe this change makes the database easier to debug.