### PR TITLE
Use coincurve instead of secp256k1 to avoid a failed installation

### DIFF
--- a/nekoyume/cli.py
+++ b/nekoyume/cli.py
@@ -4,7 +4,7 @@ import os
 
 from ptpython.repl import embed
 from raven import Client
-from secp256k1 import PrivateKey
+from coincurve import PrivateKey
 
 from nekoyume.models import Node, Block, Move, User, get_my_public_url
 from nekoyume.app import app, db

--- a/nekoyume/game.py
+++ b/nekoyume/game.py
@@ -3,7 +3,7 @@ from functools import wraps
 from flask import (Blueprint, g, request, redirect, render_template,
                    session, url_for)
 from flask_babel import Babel
-from secp256k1 import PrivateKey
+from coincurve import PrivateKey
 from sqlalchemy import func
 
 from nekoyume.models import cache, db, LevelUp, Move, Node, User

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
     'raven==6.9.0',
     'redis >= 2.10.6, < 2.11.0',
     'requests >= 2.18.4, < 2.19.0',
-    'secp256k1 >= 0.13.2, < 0.14',
+    'coincurve >= 8.0.2, < 8.1.0',
     'SQLAlchemy >= 1.2.2, < 1.3.0',
     'tablib >= 0.12.1, < 0.13.0',
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from pytest_localserver.http import WSGIServer
-from secp256k1 import PrivateKey
+from coincurve import PrivateKey
 from sqlalchemy.orm import sessionmaker
 
 from nekoyume.app import create_app

--- a/tests/game_test.py
+++ b/tests/game_test.py
@@ -1,4 +1,4 @@
-from secp256k1 import PrivateKey
+from coincurve import PrivateKey
 
 from nekoyume.models import Move, get_address
 from nekoyume.game import get_unconfirmed_move
@@ -15,19 +15,19 @@ def test_login(fx_test_client):
 def test_new_character_creation(fx_test_client, fx_session):
     privkey = PrivateKey()
     fx_test_client.post('/login', data={
-        'private_key': privkey.serialize(),
+        'private_key': privkey.to_hex(),
     }, follow_redirects=True)
 
     assert fx_session.query(Move).filter_by(
-        user_address=get_address(privkey.pubkey),
-        user_public_key=privkey.pubkey.serialize(compressed=True),
+        user_address=get_address(privkey.public_key),
+        user_public_key=privkey.public_key.format(compressed=True),
         name='create_novice'
     ).first()
 
 
 def test_move(fx_test_client, fx_session, fx_user, fx_private_key):
     rv = fx_test_client.post('/login', data={
-        'private_key': fx_private_key.serialize(),
+        'private_key': fx_private_key.to_hex(),
     }, follow_redirects=True)
     rv = fx_test_client.post('/new')
     fx_user.create_block(fx_session.query(Move).filter_by(block_id=None))

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -1,7 +1,7 @@
 import datetime
 
 import pytest
-from secp256k1 import PrivateKey, PublicKey
+from coincurve import PrivateKey, PublicKey
 
 from nekoyume.exc import InvalidMoveError
 from nekoyume.models import (Block,
@@ -244,7 +244,8 @@ def test_sync(fx_user, fx_session, fx_other_user, fx_other_session, fx_server,
     assert fx_session.query(Move).count() == 1
 
 
-def test_flush_session_while_syncing(fx_user, fx_session, fx_other_session, fx_novice_status):
+def test_flush_session_while_syncing(fx_user, fx_session, fx_other_session,
+                                     fx_novice_status):
     # 1. block validation failure scenario
     # syncing without flushing can cause block validation failure
     move = fx_user.create_novice(fx_novice_status)
@@ -252,26 +253,32 @@ def test_flush_session_while_syncing(fx_user, fx_session, fx_other_session, fx_n
     fx_session.delete(invalid_block)
 
     # syncing valid blocks from another node
-    new_blocks = [{"created_at": "2018-04-13 11:36:17.920869",
-                   "creator": "ET8ngv45qwhkDiJS1ZrUxndcGTzHxjPZDs",
-                   "difficulty": 0,
-                   "hash": "da0182c494660af0d9dd288839ceb86498708f38c800363cd46ed1730013a4d8",
-                   "id": 1,
-                   "version": 2,
-                   "moves": [],
-                   "prev_hash": None,
-                   "root_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                   "suffix": "00"},
-                  {"created_at": "2018-04-13 11:36:17.935392",
-                   "creator": "ET8ngv45qwhkDiJS1ZrUxndcGTzHxjPZDs",
-                   "difficulty": 1,
-                   "hash": "014c44b9382a45c2a70d817c090e6b78af22b8f34b57fd7edb474344f25c439c",
-                   "id": 2,
-                   "version": 2,
-                   "moves": [],
-                   "prev_hash": "da0182c494660af0d9dd288839ceb86498708f38c800363cd46ed1730013a4d8",
-                   "root_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-                   "suffix": "0b"}]
+    new_blocks = [
+        {
+            "created_at": "2018-04-13 11:36:17.920869",
+            "creator": "ET8ngv45qwhkDiJS1ZrUxndcGTzHxjPZDs",
+            "difficulty": 0,
+            "hash": "da0182c494660af0d9dd288839ceb86498708f38c800363cd46ed1730013a4d8", # noqa
+            "id": 1,
+            "version": 2,
+            "moves": [],
+            "prev_hash": None,
+            "root_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", # noqa
+            "suffix": "00"
+        },
+        {
+            "created_at": "2018-04-13 11:36:17.935392",
+            "creator": "ET8ngv45qwhkDiJS1ZrUxndcGTzHxjPZDs",
+            "difficulty": 1,
+            "hash": "014c44b9382a45c2a70d817c090e6b78af22b8f34b57fd7edb474344f25c439c", # noqa
+            "id": 2,
+            "version": 2,
+            "moves": [],
+            "prev_hash": "da0182c494660af0d9dd288839ceb86498708f38c800363cd46ed1730013a4d8", # noqa
+            "root_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", # noqa
+            "suffix": "0b"
+        }
+    ]
 
     def add_block(new_block):
         block = Block.deserialize(new_block)
@@ -281,7 +288,8 @@ def test_flush_session_while_syncing(fx_user, fx_session, fx_other_session, fx_n
     valid_block1 = add_block(new_blocks[0])
     valid_block2 = add_block(new_blocks[1])
 
-    assert invalid_block.hash == fx_session.query(Block).get(valid_block2.id - 1).hash
+    assert invalid_block.hash == \
+        fx_session.query(Block).get(valid_block2.id - 1).hash
     assert valid_block2.valid is False
 
     fx_session.query(Block).delete()
@@ -296,7 +304,8 @@ def test_flush_session_while_syncing(fx_user, fx_session, fx_other_session, fx_n
     valid_block1 = add_block(new_blocks[0])
     valid_block2 = add_block(new_blocks[1])
 
-    assert valid_block1.hash == fx_session.query(Block).get(valid_block2.id - 1).hash
+    assert valid_block1.hash == \
+        fx_session.query(Block).get(valid_block2.id - 1).hash
     assert valid_block2.valid
 
 
@@ -305,5 +314,5 @@ def test_get_address():
         '04fb0af727d1839557ea5214a7b7dd799c05dab9da63329a6c6d9836fd19a29ce'
         'bc34f7ba31877b22f6767bb1d9f376a33fc0f28f37ada368611b011c01dbef90f'
     )
-    pubkey = PublicKey(raw_key, raw=True)
+    pubkey = PublicKey(raw_key)
     assert '0x80e0b0a7cc8001086a37648f993b2bd855d0ab59' == get_address(pubkey)


### PR DESCRIPTION
[secp256k1](https://github.com/ludbb/secp256k1-py) does not support Python3.6,  it raise error when installing dependencies. 
so, changed to use the [coincurve](https://github.com/ofek/coincurve) to avoid problems.