### PR TITLE
Make redis an optional dependency (#69)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,7 +101,12 @@ ENV/
 other_test.db
 test.db
 yume.db
+yume_broker.db
+yume_result.db
 .DS_Store
 .vscode
 
 .envrc
+
+# Cache
+.yumecache

--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,10 @@ Dependencies
 ------------
 
 * `Python <http://python.org/>`_ >= 3.6
-* `Redis <https://redis.io/>`_
 * `SQLite <https://www.sqlite.org/>`_ >= 3.16.0
 * `gmp <https://gmplib.org/>`_
 * (Recommended) `PostgreSQL <https://www.postgresql.org/>`_ >= 9.5
+* (Recommended) `Redis <https://redis.io/>`_
 
 Installation
 ------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       nekoyume init --skip-sync &&
       nekoyume sync
     environment: &app_environments
+      CACHE_TYPE: redis
       DATABASE_URL: postgresql://postgres:nekoyume@postgres/nekoyume
       REDIS_URL: redis://redis:6379
     depends_on: [postgres, redis]

--- a/nekoyume/app.py
+++ b/nekoyume/app.py
@@ -55,18 +55,30 @@ def create_app():
 
     app.config.update(
         CELERY_BROKER_URL=os.environ.get(
-            'REDIS_URL', 'redis://localhost:6379'),
+            'CELERY_BROKER_URL', 'sqla+sqlite:///yume_broker.db'),
         CELERY_RESULT_BACKEND=os.environ.get(
-            'REDIS_URL', 'redis://localhost:6379'))
+            'CELERY_RESULT_BACKEND', 'db+sqlite:///yume_reuslt.db'))
     return app
 
 
 app = create_app()
 cel = make_celery(app)
-cache.init_app(app, config={'CACHE_TYPE': 'redis',
-                            'CACHE_REDIS_URL': os.environ.get(
-                                'REDIS_URL', 'redis://localhost:6379'
-                            )})
+
+cache_type = os.environ.get('CACHE_TYPE', 'filesystem')
+if cache_type == 'redis':
+    cache_config = {
+        'CACHE_TYPE': cache_type,
+        'CACHE_REDIS_URL': os.environ.get(
+            'REDIS_URL', 'redis://localhost:6379'
+        ),
+    }
+else:
+    cache_config = {
+        'CACHE_TYPE': cache_type,
+        'CACHE_DIR': os.environ.get('CACHE_DIR', '.yumecache'),
+    }
+
+cache.init_app(app, cache_config)
 sentry = Sentry(app)
 
 


### PR DESCRIPTION
Fix #69 

- Add `CACHE_TYPE` to configure internal cache type (default `filesystem`).
  - default cache directory is `.nekocache`
- Added `CELERY_BROKER_URL` and `CELERY_RESULT_BACKEND` to configure celery.
  - default database files are `yume_broker.db` and `yume_result.db`