### PR TITLE
Prevent hack & slash when avatar.dead

### DIFF
--- a/nekoyume/game.py
+++ b/nekoyume/game.py
@@ -130,7 +130,7 @@ def post_move():
         return redirect(url_for('.get_dashboard'))
 
     if request.values.get('name') == 'hack_and_slash':
-        if g.user.avatar().is_dead:
+        if g.user.avatar().dead:
             return redirect(url_for('.get_dashboard'))
         move = g.user.hack_and_slash(request.values.get('weapon'),
                                      request.values.get('armor'),

--- a/nekoyume/game.py
+++ b/nekoyume/game.py
@@ -130,6 +130,8 @@ def post_move():
         return redirect(url_for('.get_dashboard'))
 
     if request.values.get('name') == 'hack_and_slash':
+        if g.user.avatar().is_dead:
+            return redirect(url_for('.get_dashboard'))
         move = g.user.hack_and_slash(request.values.get('weapon'),
                                      request.values.get('armor'),
                                      request.values.get('food'),)

--- a/nekoyume/models.py
+++ b/nekoyume/models.py
@@ -678,6 +678,8 @@ class HackAndSlash(Move):
     def execute(self, avatar=None):
         if not avatar:
             avatar = Avatar.get(self.user_address, self.block_id - 1)
+        if avatar.dead:
+            raise InvalidMoveError
         dirname = os.path.dirname(__file__)
         filename = os.path.join(dirname, 'data/monsters.csv')
         monsters = tablib.Dataset().load(

--- a/nekoyume/models.py
+++ b/nekoyume/models.py
@@ -1355,7 +1355,7 @@ class Avatar():
 
     @property
     def is_dead(self) -> bool:
-        return bool(self.hp <= 0)
+        return self.hp <= 0
 
 
 class Novice(Avatar):

--- a/nekoyume/models.py
+++ b/nekoyume/models.py
@@ -1354,7 +1354,7 @@ class Avatar():
         return result
 
     @property
-    def is_dead(self) -> bool:
+    def dead(self) -> bool:
         return self.hp <= 0
 
 

--- a/nekoyume/models.py
+++ b/nekoyume/models.py
@@ -1353,6 +1353,10 @@ class Avatar():
 
         return result
 
+    @property
+    def is_dead(self) -> bool:
+        return bool(self.hp <= 0)
+
 
 class Novice(Avatar):
     @property

--- a/nekoyume/templates/dashboard.html
+++ b/nekoyume/templates/dashboard.html
@@ -327,14 +327,14 @@
                   <div class="move-bar-normal mdl-tabs mdl-js-tabs mdl-js-ripple-effect
                               {% if unconfirmed_move %} hidden {% endif %}">
                     <div class="mdl-tabs__tab-bar">
-                        <a href="#hack-and-slash-panel" class="mdl-tabs__tab is-active">⚔️ {% trans -%} Hack &amp; Slash {%- endtrans %}</a>
-                        <a href="#sleep-panel" class="mdl-tabs__tab">💤 {% trans -%} Sleep {%- endtrans %}</a>
+                        <a href="#hack-and-slash-panel" class="mdl-tabs__tab {% if not avatar.is_dead -%} is-active {%- endif -%}">⚔️ {% trans -%} Hack &amp; Slash {%- endtrans %}</a>
+                        <a href="#sleep-panel" class="mdl-tabs__tab  {% if avatar.is_dead -%} is-active {%- endif -%}">💤 {% trans -%} Sleep {%- endtrans %}</a>
                         <a href="#say-panel" class="mdl-tabs__tab">🗣 {% trans -%} Say {%- endtrans %}</a>
                         <a href="#send-panel" class="mdl-tabs__tab">➡️ {% trans -%} Send {%- endtrans %}</a>
                         <a href="#combine-panel" class="mdl-tabs__tab">🙌 {% trans -%} combine {%- endtrans %}</a>
                     </div>
 
-                    <div class="mdl-tabs__panel is-active" id="hack-and-slash-panel">
+                    <div class="mdl-tabs__panel {% if not avatar.is_dead -%} is-active {%- endif -%}" id="hack-and-slash-panel">
                         <div class="mdl-card__supporting-text" style="width: auto;">
                             <center>{% trans -%}Encounter a nearby monster and battle it.{%- endtrans %}</center>
                         </div>
@@ -370,13 +370,13 @@
                                       {% endfor %}
                                     </select>
                                   </p>
-                                  <input type="submit" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" value="{% trans -%}Find monster{%- endtrans %}">
+                                  <input type="submit" {% if avatar.is_dead %} disabled {% endif %} class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" value="{% trans -%}Find monster{%- endtrans %}">
 
                                 </center>
                             </form>
                         </div>
                     </div>
-                    <div class="mdl-tabs__panel" id="sleep-panel">
+                    <div class="mdl-tabs__panel {% if avatar.is_dead -%} is-active {%- endif -%}" id="sleep-panel">
                         <div class="mdl-card__supporting-text" style="width: auto;">
                             <center>{% trans -%}Take your sleep and regain your HP.{%- endtrans %}</center>
                         </div>

--- a/nekoyume/templates/dashboard.html
+++ b/nekoyume/templates/dashboard.html
@@ -327,14 +327,14 @@
                   <div class="move-bar-normal mdl-tabs mdl-js-tabs mdl-js-ripple-effect
                               {% if unconfirmed_move %} hidden {% endif %}">
                     <div class="mdl-tabs__tab-bar">
-                        <a href="#hack-and-slash-panel" class="mdl-tabs__tab {% if not avatar.is_dead -%} is-active {%- endif -%}">⚔️ {% trans -%} Hack &amp; Slash {%- endtrans %}</a>
-                        <a href="#sleep-panel" class="mdl-tabs__tab  {% if avatar.is_dead -%} is-active {%- endif -%}">💤 {% trans -%} Sleep {%- endtrans %}</a>
+                        <a href="#hack-and-slash-panel" class="mdl-tabs__tab {% if not avatar.dead -%} is-active {%- endif -%}">⚔️ {% trans -%} Hack &amp; Slash {%- endtrans %}</a>
+                        <a href="#sleep-panel" class="mdl-tabs__tab  {% if avatar.dead -%} is-active {%- endif -%}">💤 {% trans -%} Sleep {%- endtrans %}</a>
                         <a href="#say-panel" class="mdl-tabs__tab">🗣 {% trans -%} Say {%- endtrans %}</a>
                         <a href="#send-panel" class="mdl-tabs__tab">➡️ {% trans -%} Send {%- endtrans %}</a>
                         <a href="#combine-panel" class="mdl-tabs__tab">🙌 {% trans -%} combine {%- endtrans %}</a>
                     </div>
 
-                    <div class="mdl-tabs__panel {% if not avatar.is_dead -%} is-active {%- endif -%}" id="hack-and-slash-panel">
+                    <div class="mdl-tabs__panel {% if not avatar.dead -%} is-active {%- endif -%}" id="hack-and-slash-panel">
                         <div class="mdl-card__supporting-text" style="width: auto;">
                             <center>{% trans -%}Encounter a nearby monster and battle it.{%- endtrans %}</center>
                         </div>
@@ -370,13 +370,13 @@
                                       {% endfor %}
                                     </select>
                                   </p>
-                                  <input type="submit" {% if avatar.is_dead %} disabled {% endif %} class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" value="{% trans -%}Find monster{%- endtrans %}">
+                                  <input type="submit" {% if avatar.dead %} disabled {% endif %} class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent" value="{% trans -%}Find monster{%- endtrans %}">
 
                                 </center>
                             </form>
                         </div>
                     </div>
-                    <div class="mdl-tabs__panel {% if avatar.is_dead -%} is-active {%- endif -%}" id="sleep-panel">
+                    <div class="mdl-tabs__panel {% if avatar.dead -%} is-active {%- endif -%}" id="sleep-panel">
                         <div class="mdl-card__supporting-text" style="width: auto;">
                             <center>{% trans -%}Take your sleep and regain your HP.{%- endtrans %}</center>
                         </div>

--- a/tests/game_test.py
+++ b/tests/game_test.py
@@ -1,8 +1,8 @@
 import typing
 
 from coincurve import PrivateKey
+from flask.testing import FlaskClient
 from sqlalchemy.orm.session import Session
-from werkzeug.test import Client
 
 from nekoyume.models import Move, User, get_address
 from nekoyume.game import get_unconfirmed_move
@@ -81,7 +81,7 @@ def test_get_unconfirmed_move(fx_session, fx_user, fx_novice_status):
 
 
 def test_prevent_hack_and_slash_when_dead(
-        fx_test_client: Client, fx_session: Session, fx_user: User,
+        fx_test_client: FlaskClient, fx_session: Session, fx_user: User,
         fx_private_key: PrivateKey, fx_novice_status: typing.Dict[str, str],
 ):
     move = fx_user.create_novice(fx_novice_status)

--- a/tests/game_test.py
+++ b/tests/game_test.py
@@ -84,7 +84,6 @@ def test_prevent_hack_and_slash_when_dead(
         fx_test_client: Client, fx_session: Session, fx_user: User,
         fx_private_key: PrivateKey, fx_novice_status: typing.Dict[str, str],
 ):
-    fx_user.create_block(fx_session.query(Move).filter_by(block_id=None))
     move = fx_user.create_novice(fx_novice_status)
     fx_user.create_block([move])
 

--- a/tests/game_test.py
+++ b/tests/game_test.py
@@ -87,11 +87,11 @@ def test_prevent_hack_and_slash_when_dead(
     move = fx_user.create_novice(fx_novice_status)
     fx_user.create_block([move])
 
-    assert fx_user.avatar().is_dead is False
+    assert fx_user.avatar().dead is False
     while fx_user.avatar().hp > 0:
         move = fx_user.hack_and_slash()
         fx_user.create_block([move])
-    assert fx_user.avatar().is_dead is True
+    assert fx_user.avatar().dead is True
 
     response = fx_test_client.post('/session_moves', data={
         'name': 'hack_and_slash'

--- a/tests/models_test.py
+++ b/tests/models_test.py
@@ -316,3 +316,14 @@ def test_get_address():
     )
     pubkey = PublicKey(raw_key)
     assert '0x80e0b0a7cc8001086a37648f993b2bd855d0ab59' == get_address(pubkey)
+
+
+def test_hack_and_slash_execute(fx_user, fx_novice_status):
+    move = fx_user.create_novice(fx_novice_status)
+    fx_user.create_block([move])
+    avatar = fx_user.avatar()
+    avatar.hp = 0
+    move = fx_user.move(HackAndSlash())
+    fx_user.create_block([move])
+    with pytest.raises(InvalidMoveError):
+        move.execute(avatar)


### PR DESCRIPTION
solved #52 

- prevent hack_and_slash move when avatar is dead
- disable find monster button when avatar is dead
- active sleep tab instead of hack & slash when avatar is dead

![image](https://user-images.githubusercontent.com/3193043/44131331-3c323e04-a08d-11e8-9d26-bf46710ebc3c.png)
