### PR TITLE
Remove unusing pycrypto dependency (#63)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ install_requires = [
     'gunicorn >= 19.9.0',
     'psycopg2 >= 2.7.5, < 2.8.0',
     'ptpython == 0.41',
-    'pycrypto == 2.6',
     'pytz >= 2018.3',
     'raven==6.9.0',
     'redis >= 2.10.6, < 2.11.0',


### PR DESCRIPTION
Fix #63 

Remove `pycrypto` from depedencies since there is no place using it.