### PR TITLE
Add try-except for UNIQUE contraint error

### DIFF
--- a/nekoyume/models.py
+++ b/nekoyume/models.py
@@ -1191,8 +1191,11 @@ class User():
             raise InvalidBlockError
 
         if commit:
-            self.session.add(block)
-            self.session.commit()
+            try:
+                self.session.add(block)
+                self.session.commit()
+            except IntegrityError:
+                return None
 
         return block
 


### PR DESCRIPTION
#85 
To handle UNIQUE constraint failed on `block.id` or other unique attributes, I've added try-except statement to catch the IntegrityError.
It will return `None` to ignore this conflicting block and continue with the while loop to create a new one instead.

A test case for this issue isn't included; I wasn't able to reproduce the incident.