### PR TITLE
Update readme to prepare for japan sprint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,17 +23,6 @@ Dependencies
 Installation
 ------------
 
-Installation to local environment
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code-block:: console
-
-   $ pip install nekoyume
-   $ nekoyume init
-
-Installation to Heroku
-^^^^^^^^^^^^^^^^^^^^^^^
-|deploy|
-
 Installation for development
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Removed two sections:

- Installation for local environment

    - Might be confused with installation for local development.

    - Redundant in case of people reading from pypi

- Deploy to heroku

   - It dont work
