### PR TITLE
Adjust signature length limit (#114)

### DIFF
--- a/nekoyume/models.py
+++ b/nekoyume/models.py
@@ -534,7 +534,7 @@ class Move(db.Model):
             return False
 
         assert isinstance(self.signature, bytes)
-        assert 70 <= len(self.signature) <= 71
+        assert 68 <= len(self.signature) <= 71
         assert isinstance(self.user_public_key, bytes)
         assert len(self.user_public_key) == 33
         assert isinstance(self.user_address, str)


### PR DESCRIPTION
According [coincurve's documentation](https://pypi.org/project/coincurve/9.0.0/#coincurve-privatekey), return length of `PrivateKey.sign()` between 68 and 71.

> Returns: bytes. 68 <= len(signature) <= 71
