### PR TITLE
Determine canidate languages to negotiate using Flask-Babel's catalogs

### DIFF
--- a/nekoyume/game.py
+++ b/nekoyume/game.py
@@ -15,7 +15,9 @@ babel = Babel()
 
 @babel.localeselector
 def get_locale():
-    return request.accept_languages.best_match(['ko', 'en', 'ja'])
+    langs = {babel.default_locale}
+    langs.update(babel.list_translations())
+    return request.accept_languages.best_match([l.language for l in langs])
 
 
 def login_required(f):


### PR DESCRIPTION
Instead of having hard-coded list of supported languages, this patch makes `@localeselector` to take the language list from Flask-Babel's catalogs.