### PR TITLE
docker-compose setting for single node running

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ Dependencies
 * `gmp <https://gmplib.org/>`_
 * (Recommended) `PostgreSQL <https://www.postgresql.org/>`_ >= 9.5
 * (Recommended) `Redis <https://redis.io/>`_
+* (Recommended) `Docker Compose <https://docs.docker.com/compose/install/>`_
 
 Installation
 ------------
@@ -53,7 +54,16 @@ Mining
 
 .. code-block:: console
 
-   $ nekoyume neko
+   $ nekoyume neko "user private key"
+
+
+Running single node for development
+-----------------------------------
+
+.. code-block:: console
+
+   $ docker-compose build
+   $ MINER_KEY="user private key" docker-compose up
 
 
 .. |build| image:: https://circleci.com/gh/nekoyume/nekoyume.svg?style=shield&circle-token=fb83e926d78b99e4cda9788f3f3dce9e281270e3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       CELERY_BROKER_URL: redis://redis:6379
       CELERY_RESULT_BACKEND: redis://redis:6379
       REDIS_URL: redis://redis:6379
+      SEED_NODE_URL: http://web:8080
     depends_on: [postgres, redis]
     networks: [nekoyume-net]
   web:
@@ -55,5 +56,12 @@ services:
     environment:
       <<: *app_environments
       C_FORCE_ROOT: "true"
+  miner:
+    <<: *app
+    command:
+      -
+        nekoyume init --skip-sync &&
+        nekoyume neko ${MINER_KEY}
+    depends_on: [sync]
 networks:
   nekoyume-net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,10 +34,14 @@ services:
         -w 3
         -k gevent
         --log-level debug
+        --reload
         nekoyume.app:app;
+    volumes:
+    - '.:/app'
     depends_on: [sync]
     ports:
     - "4000:8080"
+    restart: always
   worker:
     <<: *app
     command:


### PR DESCRIPTION
when running node for development, can't do anything(include create account) until the end of the block sync with the seed node. so, configure single node without sync for development.