### PR TITLE
Return last_block.id when new_block.id > last_block.id + 1

### DIFF
--- a/nekoyume/api.py
+++ b/nekoyume/api.py
@@ -157,6 +157,7 @@ def post_block():
                 Node.query.order_by(
                     Node.last_connected_at.desc()).first())
         return jsonify(result='failed',
+                       block_id=last_block.id,
                        message="new block isn't our next block."), 403
 
     block = Block.deserialize(new_block)

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1,4 +1,9 @@
-from nekoyume.models import Block
+import json
+
+from flask.testing import FlaskClient
+from sqlalchemy.orm.session import Session
+
+from nekoyume.models import Block, User
 
 
 def test_get_blocks(fx_test_client, fx_user):
@@ -27,3 +32,24 @@ def test_get_blocks(fx_test_client, fx_user):
     rv = fx_test_client.get(f'/blocks/last')
     assert rv.status == '200 OK'
     assert block.hash.encode() in rv.data
+
+
+def test_post_block_return_block_id(fx_test_client: FlaskClient,
+                                    fx_user: User,
+                                    fx_session: Session):
+    block = Block.create(fx_user, [])
+    fx_session.add(block)
+    fx_session.commit()
+    block2 = Block.create(fx_user, [])
+    des = block2.serialize(use_bencode=False,
+                           include_suffix=True,
+                           include_moves=True,
+                           include_hash=True)
+    des['id'] = 3
+    resp = fx_test_client.post('/blocks', data=json.dumps(des),
+                               content_type='application/json')
+    assert resp.status_code == 403
+    data = json.loads(resp.get_data())
+    assert data['result'] == 'failed'
+    assert data['message'] == "new block isn't our next block."
+    assert data['block_id'] == 2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import os
 
 from coincurve import PrivateKey
+from flask import Flask
+from flask.testing import FlaskClient
 from pytest import fixture
 from pytest_localserver.http import WSGIServer
 from sqlalchemy.orm import sessionmaker
@@ -55,7 +57,7 @@ def fx_server(request, fx_app):
 
 
 @fixture
-def fx_test_client(fx_app):
+def fx_test_client(fx_app: Flask) -> FlaskClient:
     fx_app.testing = True
     return fx_app.test_client()
 


### PR DESCRIPTION
When a minor sends a new block, if the value is greater than the last block of the node by one or more, the node will ignore the block. However, there is no behavior when a new block is ignored, so new blocks created later are always ignored. To solve this problem, change the node to return the node's latest block ID when it returns the request.